### PR TITLE
Backend refactor and a bunch of new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ You need forester installed, see [here](https://www.jonmsterling.com/jms-005P.xm
 - Use `forester.path` to configure the path to forester. It needs to include the name of the executable too.
 - Use `forester.config` to specify the forester config file. This should usually be edited per workspace, instead of globally.
   - In the toml file, add a line `prefixes = ["prfx", ...]` to specify the prefixes to pick from. This is used when creating new trees.
+- Use `forester.defaultPrefix` to set a default prefix for new trees (e.g., 'jms', 'ssl'). If not set, you will be prompted to choose from your configured prefixes.
+- Use `forester.defaultTemplate` to set a default template for new trees (e.g., 'daily', 'paper'). If not set, you will be prompted to choose a template. Use '(No template)' to skip template selection.
 - Use `forester.completion.showID` to toggle whether the tree ID is shown in completions. It is recommended to use smaller fonts when switching on this feature. There are also plugins to create keybindings for setting toggles, in case you need to switch it on and off quickly. VSCode also has a lot of useful settings in the `editor.suggest` section worth looking at in conjunction.
 - Use `forester.create.random` to control whether the tree ID is generated randomly or sequentially.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,18 @@
         "title": "New Tree...",
         "category": "Forester",
         "icon": "$(diff-added)"
+      },
+      {
+        "command": "forester.setDefaultPrefix",
+        "title": "Set Default Prefix",
+        "category": "Forester",
+        "icon": "$(settings-gear)"
+      },
+      {
+        "command": "forester.setDefaultTemplate",
+        "title": "Set Default Template",
+        "category": "Forester",
+        "icon": "$(settings-gear)"
       }
     ],
     "configuration": {
@@ -41,6 +53,16 @@
           "type": "boolean",
           "default": false,
           "description": "Controls whether the tree ID is shown in completions."
+        },
+        "forester.defaultPrefix": {
+          "type": "string",
+          "default": "",
+          "description": "Default prefix for new trees (e.g., 'jms', 'ssl'). Will be prompted if not set."
+        },
+        "forester.defaultTemplate": {
+          "type": "string",
+          "default": "",
+          "description": "Default template for new trees (e.g., 'daily', 'paper'). Will be prompted if not set. Use '(No template)' to skip template selection."
         },
         "forester.create.random": {
           "type": "boolean",

--- a/src/get-forest.ts
+++ b/src/get-forest.ts
@@ -1,0 +1,226 @@
+/**
+ * get-forest.ts - Forest caching and management layer
+ *
+ * This module manages the cached forest data and provides high-level functions
+ * for accessing tree information with automatic caching and file watching.
+ */
+
+import * as vscode from "vscode";
+import { queryForest, Forest, ForesterTree } from "./server";
+import { getRoot } from "./utils";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+
+// Re-export types from server for convenience
+export type { Forest, ForesterTree } from "./server";
+
+// For managing the global cache flow
+let queryInProgressPromise: Promise<Forest> | null = null;
+let mostRecentQueryResult: Forest | null = null;
+let isInitialLoad = true;
+
+// File event handlers and callbacks
+let fileEventDisposables: vscode.Disposable[] = [];
+const forestChangeCallbacks = new Set<() => void>();
+
+export async function getTree(treeId: string): Promise<ForesterTree | null> {
+   // if we can find it in our most recent successful query just return (keeps things fast)
+   if (mostRecentQueryResult) {
+      let tree = mostRecentQueryResult.find((entry) => entry.uri === treeId);
+      if (tree) return tree
+   }
+
+   const forest = await getForest();
+   return forest.find((entry) => entry.uri === treeId) || null;
+}
+
+// await to return a forest array, handles all the caching logic
+export async function getForest({ forceReload, fastReturnStale }: { forceReload?: boolean, fastReturnStale?: boolean } = {}): Promise<Forest> {
+   // If there's no query in progress (or we don't care that the data might be stale) and we have some then return it (unless we're forcing a reload). A reload is forced whenever a file changes by forestUpdatedOnDisk.
+   if ((!queryInProgressPromise || fastReturnStale) && mostRecentQueryResult && !forceReload) return mostRecentQueryResult
+
+   // If we have a query in progress then return the promise which will resolve to result
+   if (queryInProgressPromise && !forceReload) return queryInProgressPromise
+
+   // Show starting notification (only for initial load)
+   if (isInitialLoad) {
+      vscode.window.showInformationMessage("🌲 Forester: Building forest cache...");
+   }
+
+   queryInProgressPromise = queryForestWithFallback()
+
+   // setting the global promise and then awaiting means that if there are calls to getForest in the meantime they will await the same promise
+   const result = mostRecentQueryResult = await queryInProgressPromise
+
+   forestChangeCallbacks.forEach(callback => {
+      try {
+         callback();
+      } catch (error) {
+         console.error('Error in forest change callback:', error);
+      }
+   });
+
+   // Show completion notification (only for initial load)
+   if (isInitialLoad) {
+      vscode.window.showInformationMessage(`✅ Forester: Loaded ${result.length} trees`);
+      isInitialLoad = false;
+   }
+
+   queryInProgressPromise = null
+
+   return mostRecentQueryResult || []
+}
+
+/**
+ * Query the forest with fallback to build output
+ */
+async function queryForestWithFallback(): Promise<Forest> {
+   const result = await queryForest();
+
+   // If query succeeded, return the result
+   if (result.length > 0) {
+      return result;
+   }
+
+   // If query failed, try to fall back to most recent in-memory success
+   if (mostRecentQueryResult) {
+      return mostRecentQueryResult;
+   }
+
+   // If that doesn't work, try to get data from the most recent successful build
+   const buildData = await getForestFromBuild();
+   if (buildData) {
+      return buildData;
+   }
+
+   // If nothing works, return empty array
+   return [];
+}
+
+/**
+ * Initialize forest monitoring - starts watching for file changes
+ */
+export function initForestMonitoring(context: vscode.ExtensionContext) {
+   // Clean up any existing handlers
+   fileEventDisposables.forEach(d => d.dispose());
+   fileEventDisposables = [];
+
+   const forestUpdatedOnDisk = async () => {
+      // if the query takes 4s, and we call this a bunch of times in that time
+      // then the first one will create the promise, and then rest will await it
+      // and then when it's done whoever awaited first will re-do it
+      if (queryInProgressPromise) await queryInProgressPromise
+
+      await getForest({ forceReload: true })
+   }
+
+   // Watch for .tree file changes using workspace events (more reliable than createFileSystemWatcher)
+   fileEventDisposables.push(
+      // Save events catch changes made in VS Code
+      vscode.workspace.onDidSaveTextDocument((doc) => {
+         if (doc.fileName.endsWith('.tree') || doc.fileName.endsWith('forest.toml')) {
+            forestUpdatedOnDisk();
+         }
+      }),
+
+      // File creation events
+      vscode.workspace.onDidCreateFiles((event) => {
+         if (event.files.some(uri => uri.fsPath.endsWith('.tree') || uri.fsPath.endsWith('forest.toml'))) {
+            forestUpdatedOnDisk();
+         }
+      }),
+
+      // File deletion events
+      vscode.workspace.onDidDeleteFiles((event) => {
+         if (event.files.some(uri => uri.fsPath.endsWith('.tree') || uri.fsPath.endsWith('forest.toml'))) {
+            forestUpdatedOnDisk();
+         }
+      }),
+
+      // File rename events
+      vscode.workspace.onDidRenameFiles((event) => {
+         if (event.files.some(f => f.oldUri.fsPath.endsWith('.tree') || f.newUri.fsPath.endsWith('.tree') ||
+            f.oldUri.fsPath.endsWith('forest.toml') || f.newUri.fsPath.endsWith('forest.toml'))) {
+            forestUpdatedOnDisk();
+         }
+      })
+   );
+
+   // Add to subscriptions for cleanup
+   context.subscriptions.push(...fileEventDisposables);
+
+   // Trigger initial load
+   getForest({ forceReload: true })
+}
+
+
+/**
+ * Register a callback to be called when the forest changes
+ * Returns a disposable to unregister the callback
+ */
+export function onForestChange(callback: () => void): vscode.Disposable {
+   forestChangeCallbacks.add(callback);
+
+   // If we already have cached results, call the callback immediately
+   if (mostRecentQueryResult) {
+      callback();
+   }
+
+   return new vscode.Disposable(() => {
+      forestChangeCallbacks.delete(callback);
+   });
+}
+
+
+/**
+ * Cleanup function for extension deactivation
+ */
+export function cleanupServer(): void {
+   // Dispose file event handlers
+   fileEventDisposables.forEach(d => d.dispose());
+   fileEventDisposables = [];
+
+   // Clear callbacks
+   forestChangeCallbacks.clear();
+
+   // Clear cache
+   queryInProgressPromise = null;
+   mostRecentQueryResult = null;
+}
+
+/**
+ * Read forest.json from the output directory
+ * This provides an alternative way to get the forest data from the built output
+ * The structure matches ForesterTree[] exactly
+ */
+export async function getForestFromBuild(): Promise<Forest | null> {
+   try {
+      const root = getRoot();
+      const outputPath = join(root.fsPath, "output", "forest.json");
+
+      if (!existsSync(outputPath)) return null
+
+      const content = await readFile(outputPath, "utf-8");
+      const data = JSON.parse(content) as Forest;
+
+      // Validate that it's an array of ForesterTree objects
+      if (!Array.isArray(data)) {
+         console.error("forest.json is not an array");
+         return null;
+      }
+
+      // Basic validation of the structure
+      for (const tree of data) {
+         if (typeof tree.uri !== "string") {
+            console.error("Invalid tree structure in forest.json: missing uri");
+            return null;
+         }
+      }
+
+      return data;
+   } catch (error) {
+      console.error("Failed to read forest.json from output:", error);
+      return null;
+   }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,168 @@
+/**
+ * utils.ts - Common utilities for the Forester extension
+ */
+
+import * as vscode from "vscode";
+import { readFile, access, constants } from "fs/promises";
+import { join } from "path";
+import { load } from "js-toml";
+
+/**
+ * TypeScript interface for forest.toml configuration
+ * Based on Forester OCaml types in lib/core/Config.ml
+ */
+export interface ForestConfig {
+   forest?: {
+      trees?: string[];
+      assets?: string[];
+      prefixes?: string[];
+      url?: string;
+      home?: string;
+
+      /** Import trees from external forests */
+      foreign?: Array<{
+         path: string;
+         route_locally?: boolean;
+      }>;
+   };
+}
+
+/**
+ * Get the root workspace folder.
+ * Throws an error if no workspace is open or if opening a single file.
+ */
+export function getRoot(): vscode.Uri {
+   if (vscode.workspace.workspaceFolders?.length) {
+      if (vscode.workspace.workspaceFolders.length !== 1) {
+         vscode.window.showWarningMessage(
+            "vscode-forester only supports opening one workspace folder.",
+         );
+      }
+      return vscode.workspace.workspaceFolders[0].uri;
+   } else {
+      // Probably opened a single file
+      throw new vscode.FileSystemError(
+         "vscode-forester doesn't support opening a single file.",
+      );
+   }
+}
+
+export async function getForestConfig(): Promise<ForestConfig | null> {
+   const root = getRoot();
+   const config = vscode.workspace.getConfiguration("forester");
+   let configFile = config.get<string>("config") || "forest.toml";
+
+   const configPath = join(root.fsPath, configFile);
+   const content = await readFile(configPath, "utf-8");
+
+   return load(content)
+}
+
+/**
+ * Get the trees directories from forest.toml config
+ */
+export async function getTreesDirectories(): Promise<string[]> {
+   try {
+      const config = await getForestConfig()
+      return config?.forest?.trees || ["trees"]; // Default to ["trees"] if not specified
+   } catch (error) {
+      console.error("Failed to read forest.toml, defaulting to 'trees' directory:", error);
+      return ["trees"];
+   }
+}
+
+/**
+ * Get the root trees directory for creating new trees
+ */
+export async function getRootTreeDirectory(): Promise<vscode.Uri> {
+   const root = getRoot();
+   const dirs = await getTreesDirectories();
+   // Use the first directory as the root one
+   return vscode.Uri.joinPath(root, dirs[0]);
+}
+
+/**
+ * Get available templates from the templates directory
+ * @returns Array of template names (without .tree extension), plus "(No template)" option
+ */
+export async function getAvailableTemplates(): Promise<string[]> {
+   const root = getRoot();
+   let templates: string[] = [];
+
+   try {
+      const templateFiles = await vscode.workspace.fs.readDirectory(
+         vscode.Uri.joinPath(root, 'templates')
+      );
+      templates = templateFiles
+         .filter(([n, f]) => f === vscode.FileType.File && n.endsWith(".tree"))
+         .map(([n, f]) => n.slice(0, -5));
+   } catch {
+      // templates directory doesn't exist, return empty array
+   }
+
+   templates.push("(No template)");
+   return templates;
+}
+
+/**
+ * Get the template for new trees, checking default first, then prompting if needed
+ * @returns Template name, undefined if no template selected, or undefined if cancelled
+ */
+export async function getTemplate(): Promise<string | undefined> {
+   const extensionConfig = vscode.workspace.getConfiguration("forester");
+   const defaultTemplate = extensionConfig.get<string>('defaultTemplate');
+
+   // If default template is set, use it
+   if (defaultTemplate) {
+      return defaultTemplate !== "(No template)" ? defaultTemplate : undefined;
+   }
+
+   // Otherwise prompt for template
+   const templates = await getAvailableTemplates();
+
+   const template = await vscode.window.showQuickPick(templates, {
+      canPickMany: false,
+      placeHolder: "Choose a template or Escape to cancel",
+      title: "Choose template"
+   });
+
+   if (template === undefined) {
+      return undefined;  // Cancelled
+   } else if (template === "(No template)") {
+      return undefined;  // No template
+   }
+
+   return template;
+}
+
+/**
+ * Get the prefix for new trees from config, or prompt if not set
+ */
+export async function getPrefix(): Promise<string | undefined> {
+   // Get prefixes from configuration
+   const extensionConfig = vscode.workspace.getConfiguration("forester")
+
+   const defaultPrefix = extensionConfig.get<string>('defaultPrefix')
+   if (defaultPrefix) return defaultPrefix
+
+   const configToml = await getForestConfig()
+   const prefixes = configToml?.forest?.prefixes;
+
+   let prefix: string | undefined;
+   if (prefixes) {
+      prefix = await vscode.window.showQuickPick(prefixes, {
+         canPickMany: false,
+         placeHolder: "Choose prefix or Escape to use a new one (run the \"set default prefix\" command if you always use the same prefix)",
+         title: "Choose prefix"
+      });
+   }
+
+   if (!prefix) {
+      prefix = await vscode.window.showInputBox({
+         placeHolder: "Enter a prefix or Escape to cancel (run the \"set default prefix\" command if you always use the same prefix)",
+         title: "Enter prefix"
+      });
+   }
+
+   return prefix;
+}


### PR DESCRIPTION
Hello! I've been doing some work for the [topos institute](https://topos.institute/) that's involved making some enhancements to their forester workflow.

My starting place was forking your repo, and I'd love it if the work I've done could be merged back so anyone who uses forester via vscode can benefit. I've done some testing on my machine as has my friend with a mac, but I could also imagine releasing a "pre-release" extension version and then calling for beta testers on the forester message board if you weren't comfortable just pushing such a big change out.

The main changes at a high level were:

- A refactor of server.ts to make it easier to get a cached representation of the forest from many places
- A set of commands to make it easier to create and rename trees
- A status bar item that shows red if the forest is in an invalid state
- An experimental explorer view that shows the transclusion structure of the forest and lets you navigate to trees via clicking.